### PR TITLE
feature/instagram-post-desktop

### DIFF
--- a/templates/instagramPostBanner.hbs
+++ b/templates/instagramPostBanner.hbs
@@ -3,11 +3,11 @@
     <div class="row justify-content-center">
       <div class="instagram-post__image col-10 col-sm-6 col-md-6 col-lg-3">
         <figure class="instagram-post__figure">
-          <img src="images/instagramPostImage.png" alt="">
+          {{{asset postImage}}}
         </figure>
       </div>
       <div class="instagram-post__content col-12 col-lg-3">
-        <h3 class="instagram-post__title">¡No te pierdas nuestro contenido en Instagram!</h3>
+        <h3 class="instagram-post__title">{{title}}</h3>
         <div class="instagram-post__link">
           {{{module buttonLink}}}
         </div>


### PR DESCRIPTION
# FooCamp - Salvadores

## Trello ticket
[Instagram Post Banner - Desktop](https://trello.com/c/w9Bk9p88/24-2-desk-instagram-post-banner)
[Instagram Post Banner - Mobile](https://trello.com/c/JfZQ6JGh/25-3-mob-instagram-post-banner)

## Description
Add Instagram Post Banner component. Both DESKTOP and MOBILE views

## To reproduce

1. Run the project
2. Open the specific page (http://localhost:8080/gio-tapabocas.html)
3. Check the component Instagram Post Banner

## Screenshots
Instagram Post Banner - DESKTOP

![Evidence - Instagram Post Banner DESKTOP](https://user-images.githubusercontent.com/23706696/135380114-2d82ffab-96fb-4a20-a186-f25e9a4c710b.png)


Instagram Post Banner - MOBILE

![Evidence - Instagram Post Banner MOBILE](https://user-images.githubusercontent.com/23706696/135380140-d7608348-eca4-478b-bcad-2eefa8e524c6.png)


